### PR TITLE
Add Swagger documentation enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
+## API Documentation
+
+After starting the application, Swagger UI is available at [`http://localhost:3000/api`](http://localhost:3000/api).
+
 ## Run tests
 
 ```bash

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Post, Request, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
@@ -13,6 +15,7 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
   @Post('profile')
   async getProfile(@Request() req) {
     return req.user;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function bootstrap() {
     .setTitle('API Fornecedores')
     .setDescription('Documentação da API de fornecedores')
     .setVersion('1.0')
+    .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -3,7 +3,10 @@ import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@n
 import { UserService } from './user.service';
 import { CreateUserDto, UpdateUserDto } from './user.dto';
 import { JwtAuthGuard } from 'src/guards/jwt-auth.guard';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('users')
+@ApiBearerAuth()
 @Controller('users')
 @UseGuards(JwtAuthGuard)
 export class UserController {


### PR DESCRIPTION
## Summary
- enable bearer authentication in Swagger setup
- document Swagger UI path in README
- annotate auth and user controllers for Swagger

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e29de94c832cb2a514db51513c6c